### PR TITLE
add a command option to filter on file extension

### DIFF
--- a/Console/Command/CheckOverrideCommand.php
+++ b/Console/Command/CheckOverrideCommand.php
@@ -51,6 +51,7 @@ class CheckOverrideCommand extends Command
     {
         $this->setName('yireo:theme-overrides:check')
             ->setDescription('Check the overrides of a specified theme')
+            ->addOption('extension', '-e', InputOption::VALUE_OPTIONAL, 'Filter the checked files by extension (for example xml, phtml, ...)')
             ->addArgument('theme', InputOption::VALUE_REQUIRED, 'Theme name');
     }
 
@@ -100,6 +101,11 @@ class CheckOverrideCommand extends Command
         ]);
 
         $themeFiles = $this->finder->in($themePath)->files();
+
+        if($input->getOption('extension')) {
+            $themeFiles->name('*.' . $input->getOption('extension'));
+        }
+
         foreach ($themeFiles as $themeFile) {
             $parentThemeFile = null;
             $lineDiff = 0;


### PR DESCRIPTION
with this extra option one can focus on a specific type of files. useful for large themes with many overrides to have a shorter list of files.
```yireo:theme-overrides:check Glue/boilerplate_hyva --extension=phtml```